### PR TITLE
Fix void tags closing bracket and indentation for certain edge tags

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -258,6 +258,7 @@ class Printer {
     const closingIndentation = this.getIndent(
       node.type === "openingTag" ? this.level - 1 : this.level
     );
+    const closingTag = node.type == 'voidTag' ? ' />' : '>'
 
     const useLineBreak =
       !this.isInlineTag(node.tagName) && nextNode?.type !== "linebreak";
@@ -269,6 +270,7 @@ class Printer {
         previousNode?.type === "edgeSafeMustache") &&
       this.isInlineTag(node.tagName)
     );
+
     if (combinedLength > this.printWidth || this.singleAttributePerLine) {
       attrs = this.formatAttributes(node.attributes, indentation);
       edgeProps = this.formatEdgeProps(node.edgeProps, indentation);
@@ -283,10 +285,10 @@ class Printer {
         edgeTagProps
           ? `\n${this.formatMultilineValue(edgeTagProps, indentation)}`
           : ""
-      }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}>${useLineBreak ? "\n" : ""}`;
+      }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}${closingTag}${useLineBreak ? "\n" : ""}`;
     }
 
-    return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? ` ${attrs}` : ""}${edgeMustaches ? ` ${edgeMustaches}` : ""}${edgeProps ? ` ${edgeProps}` : ""}${edgeTagProps ? ` ${this.formatMultilineValue(edgeTagProps, "")}` : ""}${comments ? ` ${this.formatMultilineValue(comments, "")}` : ""}>${useLineBreak ? "\n" : ""}`;
+    return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? ` ${attrs}` : ""}${edgeMustaches ? ` ${edgeMustaches}` : ""}${edgeProps ? ` ${edgeProps}` : ""}${edgeTagProps ? ` ${this.formatMultilineValue(edgeTagProps, "")}` : ""}${comments ? ` ${this.formatMultilineValue(comments, "")}` : ""}${closingTag}${useLineBreak ? "\n" : ""}`;
   }
 
   private printClosingNode(
@@ -315,6 +317,8 @@ class Printer {
       node.value.includes("@let") ||
       node.value.includes("@svg") ||
       node.value.includes("@assign") ||
+      node.value.includes("@inject") ||
+      node.value.includes("@eval") ||
       node.value.includes("@vite") ||
       node.value.match(/^@include\(.*/)?.length ||
       node.value.match(/^@includeIf\(.*/)?.length ||

--- a/src/print.ts
+++ b/src/print.ts
@@ -258,7 +258,6 @@ class Printer {
     const closingIndentation = this.getIndent(
       node.type === "openingTag" ? this.level - 1 : this.level
     );
-    const closingTag = node.type == 'voidTag' ? ' />' : '>'
 
     const useLineBreak =
       !this.isInlineTag(node.tagName) && nextNode?.type !== "linebreak";
@@ -272,6 +271,7 @@ class Printer {
     );
 
     if (combinedLength > this.printWidth || this.singleAttributePerLine) {
+      const closingTag = node.type == 'voidTag' ? '/>' : '>'
       attrs = this.formatAttributes(node.attributes, indentation);
       edgeProps = this.formatEdgeProps(node.edgeProps, indentation);
       edgeTagProps = this.formatEdgeTagProps(node.edgeTagProps, indentation);
@@ -288,6 +288,7 @@ class Printer {
       }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}${closingTag}${useLineBreak ? "\n" : ""}`;
     }
 
+    const closingTag = node.type == 'voidTag' ? ' />' : '>'
     return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? ` ${attrs}` : ""}${edgeMustaches ? ` ${edgeMustaches}` : ""}${edgeProps ? ` ${edgeProps}` : ""}${edgeTagProps ? ` ${this.formatMultilineValue(edgeTagProps, "")}` : ""}${comments ? ` ${this.formatMultilineValue(comments, "")}` : ""}${closingTag}${useLineBreak ? "\n" : ""}`;
   }
 

--- a/src/print.ts
+++ b/src/print.ts
@@ -247,6 +247,8 @@ class Printer {
     let edgeMustaches = this.formatEdgeProps(node.edgeMustaches);
     let comments = this.formatComments(node.comments);
 
+    const closingTag = node.type == "voidTag" ? " />" : ">";
+
     const combinedLength =
       `${attrs} ${edgeProps} ${edgeMustaches} ${edgeTagProps} ${comments}`
         .length;
@@ -271,7 +273,6 @@ class Printer {
     );
 
     if (combinedLength > this.printWidth || this.singleAttributePerLine) {
-      const closingTag = node.type == 'voidTag' ? '/>' : '>'
       attrs = this.formatAttributes(node.attributes, indentation);
       edgeProps = this.formatEdgeProps(node.edgeProps, indentation);
       edgeTagProps = this.formatEdgeTagProps(node.edgeTagProps, indentation);
@@ -288,7 +289,6 @@ class Printer {
       }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}${closingTag}${useLineBreak ? "\n" : ""}`;
     }
 
-    const closingTag = node.type == 'voidTag' ? ' />' : '>'
     return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? ` ${attrs}` : ""}${edgeMustaches ? ` ${edgeMustaches}` : ""}${edgeProps ? ` ${edgeProps}` : ""}${edgeTagProps ? ` ${this.formatMultilineValue(edgeTagProps, "")}` : ""}${comments ? ` ${this.formatMultilineValue(comments, "")}` : ""}${closingTag}${useLineBreak ? "\n" : ""}`;
   }
 


### PR DESCRIPTION
This PR fixes the void tags such as `meta`, `path`, `link` tags to use proper closing brackets and also adds `@assign` and `@eval` to the collection of inline tags