### PR TITLE
Add formatting rules for newly introduced tags

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -365,6 +365,9 @@ class Printer {
       node.value.includes("@newError") ||
       node.value.includes("@vite") ||
       node.value.includes("@inertia") ||
+      node.value.includes("@stack") ||
+      node.value.includes("@dd") ||
+      node.value.includes("@dump") ||
       node.value.match(/^@include\(.*/)?.length ||
       node.value.match(/^@includeIf\(.*/)?.length ||
       !node.value.includes("(")


### PR DESCRIPTION
The tags includes

- `@stack`: https://edgejs.dev/docs/stacks
- `@dd` and `@dump`: Yet to be documented in AdonisJS docs