### PR TITLE
Cascade layers crashes prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,22 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "css": "^3.0.0",
+        "@adobe/css-tools": "^4.4.3",
         "edgejs-parser": "^0.2.15",
         "prettier": "^3.5.3",
         "uglify-js": "^3.19.2"
       },
       "devDependencies": {
-        "@types/css": "^0.0.38",
         "@types/uglify-js": "^3.17.5",
         "vite": "^6.3.5",
         "vitest": "^3.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
+      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
+      "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "11.0.3",
@@ -772,13 +777,6 @@
         "win32"
       ]
     },
-    "node_modules/@types/css": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@types/css/-/css-0.0.38.tgz",
-      "integrity": "sha512-FsAy4pBnrJb8qdKmIyDy582o4Xt8pHwpCwYRmIvXw4dslA7C4436oOM+8XNnMEsV/LSculbFNaZsBZmycDjARw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -919,18 +917,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -982,17 +968,6 @@
         "lodash-es": "4.17.21"
       }
     },
-    "node_modules/css": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.6.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1009,15 +984,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/deep-eql": {
@@ -1136,12 +1102,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -1324,6 +1284,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1337,17 +1298,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/stackback": {

--- a/package.json
+++ b/package.json
@@ -36,13 +36,12 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@types/css": "^0.0.38",
     "@types/uglify-js": "^3.17.5",
     "vite": "^6.3.5",
     "vitest": "^3.1.4"
   },
   "dependencies": {
-    "css": "^3.0.0",
+    "@adobe/css-tools": "^4.4.3",
     "edgejs-parser": "^0.2.15",
     "prettier": "^3.5.3",
     "uglify-js": "^3.19.2"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import css from "css";
+import css from "@adobe/css-tools";
 import uglifyjs from "uglify-js";
 import {
   EdgeTagNode,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -102,6 +102,27 @@ describe("formatCss", () => {
       "  <style>\n    .class {\n      color: red;\n    }\n  </style>";
     expect(formatted).toBe(expected);
   });
+
+  it("should support layer rules", () => {
+    const node: StyleElementNode = {
+      type: "styleElement",
+      start: 0,
+      end: 10,
+      value:
+        "<style>@layer test; @layer test { :root { background-color: grey; } }</style>",
+    };
+    const formatted = formatCss(
+      node,
+      "  ",
+      "    ",
+      "  ",
+      {} as ParserOptions,
+      0
+    );
+    const expected =
+      "  <style>\n    @layer test;\n    \n    @layer test {\n      :root {\n        background-color: grey;\n      }\n    }\n  </style>";
+    expect(formatted).toBe(expected);
+  });
 });
 
 describe("formatJS", () => {


### PR DESCRIPTION
In our adonisjs template we get errors when running `prettier` after updating `@adonisjs/prettier-config` from 1.4.0 to 1.4.5:
https://github.com/abtion/adonisjs-template/pull/146

After some debugging I realized that the errors where caused by a `@layer` rule in a style tag.

I then  tracked it down to being an issue with [prettier-plugin-edgejs](https://github.com/sajansharmanz/prettier-plugin-edgejs), and in turn with the unmaintained `css` package.

This PR replaces the `css` package with `@adobe/css-tools` which is a maintained fork of `css` and a drop in replacement.
I added a test to ensure that layer rules now work.

Since the current tests only check a very limited set of CSS (and now `@layer` rules), I cannot say with 100% confidence that this PR won't break anything. While I'd be surprised if the `@adobe/css-tools` package does not completely overlap the CSS supported by the `css` package, maybe there could be cases where it formats CSS differently. :shrug:

In any case, I believe going from "unmaintained CSS formatting" to "maintained CSS formatting" is a benefit for this package. 