### PR TITLE
fix: implement prettier-ignore comment support

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -42,6 +42,8 @@ export class Printer {
   private printWidth: number;
   private tabWidth: number;
   private singleAttributePerLine: boolean;
+  private originalText: string;
+  private ignoreNext: "none" | "full" | "allAttributes" | string;
   private inlineTags = new Set([
     "a",
     "abbr",
@@ -98,6 +100,8 @@ export class Printer {
     this.printWidth = options.printWidth ?? 80;
     this.tabWidth = options.tabWidth ?? 4;
     this.singleAttributePerLine = options.singleAttributePerLine ?? false;
+    this.originalText = (options as any).originalText ?? "";
+    this.ignoreNext = "none";
   }
 
   private isInlineTag(tagName: string): boolean {
@@ -148,6 +152,31 @@ export class Printer {
       .join(indent ? "\n" : " ");
   }
 
+  private formatAttributesWithIgnore(
+    attributes: AttributeNode[],
+    directive: string,
+    indent = ""
+  ) {
+    return attributes
+      .map((attr) => {
+        const shouldIgnore =
+          directive === "allAttributes" ||
+          attr.attributeName === directive;
+
+        if (shouldIgnore) {
+          const original = this.getOriginalText(attr);
+          if (original) {
+            return `${indent}${original.trim()}`;
+          }
+        }
+
+        return attr.attributeValue
+          ? `${indent}${attr.attributeName}=${addEdgeSafeMustacheSpacing(addEdgeMustacheSpacing(attr.attributeValue)).trim()}`
+          : `${indent}${attr.attributeName.trim()}`;
+      })
+      .join(indent ? "\n" : " ");
+  }
+
   private formatEdgeSafeMustacheProps(
     props: EdgeSafeMustacheNode[],
     indent = ""
@@ -182,16 +211,142 @@ export class Printer {
       this.level = 0;
     }
 
-    return node.children
-      .filter(filterLineBreaks)
-      .map((child, index, array) =>
-        this.handlePrint(child, array[index - 1], array[index + 1])
-      )
-      .join("");
+    const children = node.children.filter(filterLineBreaks);
+    const parts: string[] = [];
+    let i = 0;
+
+    while (i < children.length) {
+      const child = children[i];
+      const prev = children[i - 1];
+      const next = children[i + 1];
+
+      if (
+        this.ignoreNext === "full" &&
+        child.type !== "linebreak" &&
+        child.type !== "htmlComment" &&
+        child.type !== "edgeComment"
+      ) {
+        this.ignoreNext = "none";
+
+        if (child.type === "openingTag") {
+          let depth = 1;
+          let j = i + 1;
+          while (j < children.length && depth > 0) {
+            const sibling = children[j];
+            if (
+              sibling.type === "openingTag" &&
+              sibling.tagName === child.tagName
+            ) {
+              depth++;
+            } else if (
+              sibling.type === "closingTag" &&
+              sibling.tagName === child.tagName
+            ) {
+              depth--;
+            }
+            if (depth > 0) j++;
+          }
+
+          if (j < children.length && this.originalText) {
+            const closingNode = children[j];
+            const startPos = child.start - 1;
+            let endPos = closingNode.end;
+            while (
+              endPos < this.originalText.length &&
+              this.originalText[endPos] !== ">"
+            ) {
+              endPos++;
+            }
+            if (endPos < this.originalText.length) endPos++;
+
+            const original = this.originalText.substring(startPos, endPos);
+            parts.push(`${this.getIndent()}${original.trim()}\n`);
+            i = j + 1;
+            continue;
+          }
+        }
+
+        const original = this.getOriginalText(child);
+        if (original) {
+          parts.push(`${this.getIndent()}${original.trim()}\n`);
+          i++;
+          continue;
+        }
+      }
+
+      parts.push(this.handlePrint(child, prev, next));
+      i++;
+    }
+
+    return parts.join("");
   }
 
   private printDTDNode(node: DtdNode) {
     return `${this.getIndent()}${node.value}`;
+  }
+
+  private parseIgnoreDirective(
+    text: string
+  ): "none" | "full" | "allAttributes" | string {
+    const match = text.match(
+      /prettier-ignore-attribute(?:\s+\(?\s*([\w-]+)\s*\)?)?/
+    );
+    if (match) {
+      return match[1] ? match[1] : "allAttributes";
+    }
+    if (/prettier-ignore(?!-)/.test(text)) {
+      return "full";
+    }
+    return "none";
+  }
+
+  private getOriginalText(node: ParserNode): string {
+    if (!this.originalText) return "";
+
+    if (node.type === "attribute") {
+      let endPos = node.end;
+      if (node.attributeValue && node.attributeValue.startsWith('"')) {
+        while (endPos < this.originalText.length && this.originalText[endPos] !== '"') {
+          endPos++;
+        }
+        if (endPos < this.originalText.length) endPos++;
+      }
+      return this.originalText.substring(node.start, endPos);
+    }
+
+    if (node.type === "openingTag" || node.type === "voidTag") {
+      let startPos = node.start - 1;
+      let endPos = node.end;
+
+      if (node.attributes && node.attributes.length > 0) {
+        endPos = Math.max(endPos, ...node.attributes.map((a) => a.end));
+      }
+
+      while (
+        endPos < this.originalText.length &&
+        this.originalText[endPos] !== ">" &&
+        this.originalText[endPos] !== "/"
+      ) {
+        endPos++;
+      }
+      if (
+        endPos < this.originalText.length &&
+        this.originalText[endPos] === "/"
+      ) {
+        endPos++;
+        while (
+          endPos < this.originalText.length &&
+          this.originalText[endPos] !== ">"
+        ) {
+          endPos++;
+        }
+      }
+      if (endPos < this.originalText.length) endPos++;
+
+      return this.originalText.substring(startPos, endPos);
+    }
+
+    return this.originalText.substring(node.start, node.end);
   }
 
   private printStandardNode(
@@ -202,6 +357,13 @@ export class Printer {
       | ScriptletNode
   ) {
     const isScriptlet = node.type === "scriptlet";
+
+    if (node.type === "htmlComment") {
+      const directive = this.parseIgnoreDirective(node.value);
+      if (directive !== "none") {
+        this.ignoreNext = directive;
+      }
+    }
 
     return this.formatMultilineValue(
       node.value,
@@ -232,6 +394,11 @@ export class Printer {
   }
 
   private printEdgeComment(node: EdgeCommentNode) {
+    const directive = this.parseIgnoreDirective(node.value);
+    if (directive !== "none") {
+      this.ignoreNext = directive;
+    }
+
     return this.formatMultilineValue(
       addEdgeCommentSpacing(node.value.trim()),
       this.getIndent()
@@ -282,9 +449,15 @@ export class Printer {
   private printOpeningNode(
     node: OpeningTagNode | VoidTagNode,
     previousNode: ParserNode | undefined,
-    nextNode: ParserNode | undefined
+    nextNode: ParserNode | undefined,
+    ignoreAttributeDirective: string | undefined = undefined
   ) {
-    let attrs = this.formatAttributes(node.attributes);
+    let attrs = ignoreAttributeDirective
+      ? this.formatAttributesWithIgnore(
+        node.attributes,
+        ignoreAttributeDirective
+      )
+      : this.formatAttributes(node.attributes);
     let edgeTagProps = this.formatEdgeTagProps(node.edgeTagProps);
     let edgeSafeMustaches = this.formatEdgeSafeMustacheProps(
       node.edgeSafeMustaches
@@ -317,7 +490,13 @@ export class Printer {
 
     if (combinedLength > this.printWidth || this.singleAttributePerLine) {
       const closingTag = node.type == "voidTag" ? "/>" : ">";
-      attrs = this.formatAttributes(node.attributes, indentation);
+      attrs = ignoreAttributeDirective
+        ? this.formatAttributesWithIgnore(
+          node.attributes,
+          ignoreAttributeDirective,
+          indentation
+        )
+        : this.formatAttributes(node.attributes, indentation);
       edgeTagProps = this.formatEdgeTagProps(node.edgeTagProps, indentation);
       edgeSafeMustaches = this.formatEdgeSafeMustacheProps(
         node.edgeSafeMustaches,
@@ -332,11 +511,10 @@ export class Printer {
       const closingNewline =
         combinedLength - 2 > 0 ? `\n${closingIndentation}` : "";
 
-      return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? `\n${attrs}` : ""}${edgeMustaches ? `\n${edgeMustaches}` : ""}${edgeSafeMustaches ? `\n${edgeSafeMustaches}` : ""}${
-        edgeTagProps
-          ? `\n${this.formatMultilineValue(edgeTagProps, indentation)}`
-          : ""
-      }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}${closingTag}${useLineBreak ? "\n" : ""}`;
+      return `${useIndentation ? tagIndentation : ""}<${node.tagName}${attrs ? `\n${attrs}` : ""}${edgeMustaches ? `\n${edgeMustaches}` : ""}${edgeSafeMustaches ? `\n${edgeSafeMustaches}` : ""}${edgeTagProps
+        ? `\n${this.formatMultilineValue(edgeTagProps, indentation)}`
+        : ""
+        }${comments ? `\n${this.formatMultilineValue(comments, indentation)}` : ""}${closingNewline}${closingTag}${useLineBreak ? "\n" : ""}`;
     }
 
     const closingTag = node.type == "voidTag" ? " />" : ">";
@@ -465,6 +643,20 @@ export class Printer {
     previousNode: ParserNode | undefined = undefined,
     nextNode: ParserNode | undefined = undefined
   ): string {
+    if (
+      this.ignoreNext !== "none" &&
+      this.ignoreNext !== "full" &&
+      node.type !== "linebreak" &&
+      node.type !== "htmlComment" &&
+      node.type !== "edgeComment" &&
+      (node.type === "openingTag" || node.type === "voidTag")
+    ) {
+      const directive = this.ignoreNext;
+      this.ignoreNext = "none";
+
+      return this.printOpeningNode(node, previousNode, nextNode, directive);
+    }
+
     switch (node.type) {
       case "document":
         return this.printDocumentNode(node);

--- a/tests/print.test.ts
+++ b/tests/print.test.ts
@@ -811,3 +811,218 @@ describe("DoNotPrintNode", () => {
     expect(getOutput(node)).toEqual("");
   });
 });
+
+describe("prettier-ignore", () => {
+  function getDocOutput(originalText: string, children: ParserNode[]) {
+    const node: DocumentNode = {
+      type: "document",
+      start: 0,
+      end: originalText.length,
+      children,
+    };
+    const opts = { ...options, originalText } as ParserOptions;
+    return print(createPath(node), opts);
+  }
+
+  describe("HTML comment: <!-- prettier-ignore -->", () => {
+    it("should preserve original formatting of the next node", () => {
+      const source = `<!-- prettier-ignore -->\n<div   class="x" >hello</div >`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore -->", start: 1, end: 24 },
+        { type: "linebreak", value: "\n", start: 25, end: 25 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"x"', start: 32, end: 40 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 26, end: 43,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 44, end: 48 },
+        { type: "closingTag", tagName: "div", start: 49, end: 55 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("<!-- prettier-ignore -->");
+      expect(result).toContain(`<div   class="x" >`);
+    });
+
+    it("should only affect the immediate next node", () => {
+      const source = `<!-- prettier-ignore -->\n<div   class="x" >bad</div>\n<div class="y">good</div>`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore -->", start: 1, end: 24 },
+        { type: "linebreak", value: "\n", start: 25, end: 25 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"x"', start: 32, end: 40 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 26, end: 43,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "bad", start: 44, end: 46 },
+        { type: "closingTag", tagName: "div", start: 47, end: 52 } as ClosingTagNode,
+        { type: "linebreak", value: "\n", start: 53, end: 53 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"y"', start: 60, end: 68 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 54, end: 69,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "good", start: 70, end: 73 },
+        { type: "closingTag", tagName: "div", start: 74, end: 79 } as ClosingTagNode,
+      ]);
+      expect(result).toContain(`<div   class="x" >`);
+      expect(result).toContain(`<div class="y">`);
+    });
+  });
+
+  describe("Edge comment: {{-- prettier-ignore --}}", () => {
+    it("should preserve original formatting of the next node", () => {
+      const source = `{{-- prettier-ignore --}}\n<div   class="x" >hello</div >`;
+      const result = getDocOutput(source, [
+        { type: "edgeComment", value: "{{-- prettier-ignore --}}", start: 1, end: 25 },
+        { type: "linebreak", value: "\n", start: 26, end: 26 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"x"', start: 33, end: 41 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 27, end: 44,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 45, end: 49 },
+        { type: "closingTag", tagName: "div", start: 50, end: 56 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("{{-- prettier-ignore --}}");
+      expect(result).toContain(`<div   class="x" >`);
+    });
+  });
+
+  describe("HTML comment: <!-- prettier-ignore-attribute -->", () => {
+    it("should preserve all attribute formatting but still format tag structure", () => {
+      const source = `<!-- prettier-ignore-attribute -->\n<div  class="x"   id="y" >hello</div>`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore-attribute -->", start: 1, end: 33 },
+        { type: "linebreak", value: "\n", start: 34, end: 34 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [
+            { type: "attribute", attributeName: "class", attributeValue: '"x"', start: 41, end: 50 } as AttributeNode,
+            { type: "attribute", attributeName: "id", attributeValue: '"y"', start: 54, end: 59 } as AttributeNode,
+          ],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 35, end: 61,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 62, end: 66 },
+        { type: "closingTag", tagName: "div", start: 67, end: 72 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("<!-- prettier-ignore-attribute -->");
+      expect(result).toContain(`class="x"`);
+      expect(result).toContain(`id="y"`);
+    });
+  });
+
+  describe("Edge comment: {{-- prettier-ignore-attribute --}}", () => {
+    it("should preserve all attribute formatting but still format tag structure", () => {
+      const source = `{{-- prettier-ignore-attribute --}}\n<div  class="x"   id="y" >hello</div>`;
+      const result = getDocOutput(source, [
+        { type: "edgeComment", value: "{{-- prettier-ignore-attribute --}}", start: 1, end: 34 },
+        { type: "linebreak", value: "\n", start: 35, end: 35 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [
+            { type: "attribute", attributeName: "class", attributeValue: '"x"', start: 42, end: 51 } as AttributeNode,
+            { type: "attribute", attributeName: "id", attributeValue: '"y"', start: 55, end: 60 } as AttributeNode,
+          ],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 36, end: 62,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 63, end: 67 },
+        { type: "closingTag", tagName: "div", start: 68, end: 73 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("{{-- prettier-ignore-attribute --}}");
+      expect(result).toContain(`class="x"`);
+      expect(result).toContain(`id="y"`);
+    });
+  });
+
+  describe("HTML comment: <!-- prettier-ignore-attribute (name) -->", () => {
+    it("should preserve only the named attribute, format others", () => {
+      const source = `<!-- prettier-ignore-attribute (id) -->\n<div  class="x"   id="y" >hello</div>`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore-attribute (id) -->", start: 1, end: 38 },
+        { type: "linebreak", value: "\n", start: 39, end: 39 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [
+            { type: "attribute", attributeName: "class", attributeValue: '"x"', start: 46, end: 55 } as AttributeNode,
+            { type: "attribute", attributeName: "id", attributeValue: '"y"', start: 58, end: 64 } as AttributeNode,
+          ],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 40, end: 66,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 67, end: 71 },
+        { type: "closingTag", tagName: "div", start: 72, end: 77 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("<!-- prettier-ignore-attribute (id) -->");
+      expect(result).toContain(`class="x"`);
+      expect(result).toContain(`id="y"`);
+    });
+  });
+
+  describe("Edge comment: {{-- prettier-ignore-attribute (name) --}}", () => {
+    it("should preserve only the named attribute, format others", () => {
+      const source = `{{-- prettier-ignore-attribute (id) --}}\n<div  class="x"   id="y" >hello</div>`;
+      const result = getDocOutput(source, [
+        { type: "edgeComment", value: "{{-- prettier-ignore-attribute (id) --}}", start: 1, end: 39 },
+        { type: "linebreak", value: "\n", start: 40, end: 40 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [
+            { type: "attribute", attributeName: "class", attributeValue: '"x"', start: 47, end: 56 } as AttributeNode,
+            { type: "attribute", attributeName: "id", attributeValue: '"y"', start: 59, end: 65 } as AttributeNode,
+          ],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 41, end: 67,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "hello", start: 68, end: 72 },
+        { type: "closingTag", tagName: "div", start: 73, end: 78 } as ClosingTagNode,
+      ]);
+      expect(result).toContain("{{-- prettier-ignore-attribute (id) --}}");
+      expect(result).toContain(`class="x"`);
+      expect(result).toContain(`id="y"`);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should not crash when ignore comment is the last node", () => {
+      const source = `<!-- prettier-ignore -->`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore -->", start: 1, end: 24 },
+      ]);
+      expect(result).toContain("<!-- prettier-ignore -->");
+    });
+
+    it("should handle multiple consecutive ignore comments", () => {
+      const source = `<!-- prettier-ignore -->\n<div   class="a" >A</div>\n<!-- prettier-ignore -->\n<div   class="b" >B</div>`;
+      const result = getDocOutput(source, [
+        { type: "htmlComment", value: "<!-- prettier-ignore -->", start: 1, end: 24 },
+        { type: "linebreak", value: "\n", start: 25, end: 25 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"a"', start: 32, end: 40 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 26, end: 43,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "A", start: 44, end: 44 },
+        { type: "closingTag", tagName: "div", start: 45, end: 50 } as ClosingTagNode,
+        { type: "linebreak", value: "\n", start: 51, end: 51 },
+        { type: "htmlComment", value: "<!-- prettier-ignore -->", start: 52, end: 75 },
+        { type: "linebreak", value: "\n", start: 76, end: 76 },
+        {
+          type: "openingTag", tagName: "div",
+          attributes: [{ type: "attribute", attributeName: "class", attributeValue: '"b"', start: 83, end: 91 } as AttributeNode],
+          edgeTagProps: [], edgeSafeMustaches: [], edgeMustaches: [], comments: [],
+          start: 77, end: 94,
+        } as OpeningTagNode,
+        { type: "htmlText", value: "B", start: 95, end: 95 },
+        { type: "closingTag", tagName: "div", start: 96, end: 101 } as ClosingTagNode,
+      ]);
+      expect(result).toContain(`<div   class="a" >`);
+      expect(result).toContain(`<div   class="b" >`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements support for `prettier-ignore` comment directives as documented at https://prettier.io/docs/ignore, for both HTML and Edge comment syntax.

### Supported directives

| Comment | Behaviour |
|---|---|
| `<!-- prettier-ignore -->` | Preserves original formatting of the entire next element |
| `<!-- prettier-ignore-attribute -->` | Preserves all attribute formatting on the next tag |
| `<!-- prettier-ignore-attribute (name) -->` | Preserves only the named attribute on the next tag |
| `{{-- prettier-ignore --}}` | Edge equivalent of `<!-- prettier-ignore -->` |
| `{{-- prettier-ignore-attribute --}}` | Edge equivalent of `<!-- prettier-ignore-attribute -->` |
| `{{-- prettier-ignore-attribute (name) --}}` | Edge equivalent of `<!-- prettier-ignore-attribute (name) -->` |

### Example

```edge
{{-- prettier-ignore --}}
<p class="whitespace-pre-wrap">{{ foo }}</p>